### PR TITLE
Fix typo in gradle usage example.

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -70,7 +70,7 @@ dependencies {
 
 javadoc {
     source = sourceSets.main.allJava
-    options.docletPath = configurations.umlDoclet.files.asType(List)
+    options.docletpath = configurations.umlDoclet.files.asType(List)
     options.doclet = "nl.talsmasoftware.umldoclet.UMLDoclet"
     options.addStringOption "additionalParamName", "additionalParamValue"
 }


### PR DESCRIPTION
This fixes #40: Typo in usage example for gradle integration.
Thanks @nimmzwei for submitting this!