### PR TITLE
Allow getters + setters to be rendered as Fields

### DIFF
--- a/src/main/java/nl/talsmasoftware/umldoclet/configuration/MethodConfig.java
+++ b/src/main/java/nl/talsmasoftware/umldoclet/configuration/MethodConfig.java
@@ -32,4 +32,10 @@ public interface MethodConfig {
     TypeDisplay returnType();
 
     boolean include(Visibility methodVisibility);
+
+    /**
+     * @return Whether JavaBean properties ({@code getXyz(), isXyz(), setXyz(Xyz xyz)}) methods
+     * should be rendered as Fields in UML
+     */
+    boolean javaBeanPropertiesAsFields();
 }

--- a/src/main/java/nl/talsmasoftware/umldoclet/html/ClassDiagramInserter.java
+++ b/src/main/java/nl/talsmasoftware/umldoclet/html/ClassDiagramInserter.java
@@ -36,7 +36,8 @@ import static nl.talsmasoftware.umldoclet.util.FileUtils.relativePath;
  */
 final class ClassDiagramInserter extends DiagramFile {
 
-    private final String extension, pathToCompare;
+    private final String extension;
+    private final String pathToCompare;
 
     ClassDiagramInserter(File basedir, File diagramFile, boolean hasImagesDirectory) {
         super(basedir, diagramFile);

--- a/src/main/java/nl/talsmasoftware/umldoclet/html/PackageDiagramInserter.java
+++ b/src/main/java/nl/talsmasoftware/umldoclet/html/PackageDiagramInserter.java
@@ -64,8 +64,8 @@ final class PackageDiagramInserter extends DiagramFile {
             if (!inserted) {
                 int idx = line.indexOf("<table");
                 if (idx >= 0) {
-                    line = line.substring(0, idx) + getImageTag() + System.lineSeparator() + line.substring(idx);
                     inserted = true;
+                    return line.substring(0, idx) + getImageTag() + System.lineSeparator() + line.substring(idx);
                 }
             }
             return line;

--- a/src/main/java/nl/talsmasoftware/umldoclet/javadoc/DocletConfig.java
+++ b/src/main/java/nl/talsmasoftware/umldoclet/javadoc/DocletConfig.java
@@ -284,6 +284,7 @@ public class DocletConfig implements Configuration {
         TypeDisplay paramTypes = TypeDisplay.SIMPLE;
         TypeDisplay returnType = TypeDisplay.SIMPLE;
         Set<Visibility> visibilities = EnumSet.of(PROTECTED, PUBLIC);
+        boolean javaBeanPropertiesAsFields = false;
 
         @Override
         public ParamNames paramNames() {
@@ -303,6 +304,11 @@ public class DocletConfig implements Configuration {
         @Override
         public boolean include(Visibility visibility) {
             return visibilities.contains(visibility);
+        }
+
+        @Override
+        public boolean javaBeanPropertiesAsFields() {
+            return javaBeanPropertiesAsFields;
         }
     }
 }

--- a/src/main/java/nl/talsmasoftware/umldoclet/javadoc/UMLFactory.java
+++ b/src/main/java/nl/talsmasoftware/umldoclet/javadoc/UMLFactory.java
@@ -73,6 +73,8 @@ import static nl.talsmasoftware.umldoclet.uml.Reference.Side.to;
  */
 public class UMLFactory {
 
+    private static final UmlPostProcessors POST_PROCESSORS = new UmlPostProcessors();
+
     final Configuration config;
     final ThreadLocal<Diagram> diagram = new ThreadLocal<>(); // TODO no longer needed?
     private final DocletEnvironment env;
@@ -195,7 +197,7 @@ public class UMLFactory {
         }
 
         if (config.methods().javaBeanPropertiesAsFields()) {
-            UmlPostProcessors.javaBeanPropertiesAsFieldsPostProcessor().accept(type);
+            POST_PROCESSORS.javaBeanPropertiesAsFieldsPostProcessor().accept(type);
         }
 
         return classDiagram;
@@ -261,7 +263,7 @@ public class UMLFactory {
         if (config.methods().javaBeanPropertiesAsFields()) {
             namespace.getChildren().stream()
                     .filter(Type.class::isInstance).map(Type.class::cast)
-                    .forEach(UmlPostProcessors.javaBeanPropertiesAsFieldsPostProcessor()::accept);
+                    .forEach(POST_PROCESSORS.javaBeanPropertiesAsFieldsPostProcessor()::accept);
         }
 
         return packageDiagram;

--- a/src/main/java/nl/talsmasoftware/umldoclet/javadoc/UMLFactory.java
+++ b/src/main/java/nl/talsmasoftware/umldoclet/javadoc/UMLFactory.java
@@ -29,6 +29,7 @@ import nl.talsmasoftware.umldoclet.uml.Reference;
 import nl.talsmasoftware.umldoclet.uml.Type;
 import nl.talsmasoftware.umldoclet.uml.TypeMember;
 import nl.talsmasoftware.umldoclet.uml.TypeName;
+import nl.talsmasoftware.umldoclet.uml.util.UmlPostProcessors;
 
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
@@ -191,6 +192,10 @@ public class UMLFactory {
                             .forEach(tp -> tp.updateGenericTypeVariables(foundTypeVariable));
                 }
             }
+        }
+
+        if (config.methods().javaBeanPropertiesAsFields()) {
+            UmlPostProcessors.javaBeanPropertiesAsFieldsPostProcessor().accept(type);
         }
 
         return classDiagram;

--- a/src/main/java/nl/talsmasoftware/umldoclet/javadoc/UMLFactory.java
+++ b/src/main/java/nl/talsmasoftware/umldoclet/javadoc/UMLFactory.java
@@ -258,6 +258,12 @@ public class UMLFactory {
         namespace.addChild(UmlCharacters.NEWLINE);
         references.stream().map(Reference::canonical).forEach(namespace::addChild);
 
+        if (config.methods().javaBeanPropertiesAsFields()) {
+            namespace.getChildren().stream()
+                    .filter(Type.class::isInstance).map(Type.class::cast)
+                    .forEach(UmlPostProcessors.javaBeanPropertiesAsFieldsPostProcessor()::accept);
+        }
+
         return packageDiagram;
     }
 

--- a/src/main/java/nl/talsmasoftware/umldoclet/javadoc/UMLOptions.java
+++ b/src/main/java/nl/talsmasoftware/umldoclet/javadoc/UMLOptions.java
@@ -58,31 +58,35 @@ final class UMLOptions {
     private UMLOptions(DocletConfig config, Set<Doclet.Option> standardOptions) {
         this.config = requireNonNull(config, "Configuration is <null>.");
         this.standardOptions = standardOptions;
-        this.options = new TreeSet<>(comparing(o -> o.getNames().get(0), String::compareTo)) {{
-            // Options from Standard doclet that we also support
-            add(new Option("-quiet", 0, Kind.OTHER, (args) -> config.quiet = true));
-            add(new Option("-verbose", 0, Kind.OTHER, (args) -> config.verbose = true));
-            add(new Option("-docencoding", 1, Kind.OTHER, (args) -> config.docencoding = args.get(0)));
-            add(new Option("-encoding", 1, Kind.OTHER, (args) -> config.encoding = args.get(0)));
-            add(new Option("-link", 1, Kind.OTHER, (args) -> config.externalLinks.add(new ExternalLink(config, args.get(0), args.get(0)))));
-            add(new Option("-linkoffline", 2, Kind.OTHER, (args) -> config.externalLinks.add(new ExternalLink(config, args.get(0), args.get(1)))));
-            add(new Option("-private", 0, Kind.OTHER, (args) -> config.showMembers("private")));
-            add(new Option("-package", 0, Kind.OTHER, (args) -> config.showMembers("package")));
-            add(new Option("-protected", 0, Kind.OTHER, (args) -> config.showMembers("protected")));
-            add(new Option("-public", 0, Kind.OTHER, (args) -> config.showMembers("public")));
-            add(new Option("--show-members", 1, Kind.OTHER, (args) -> config.showMembers(args.get(0))));
-            add(new Option("-d", 1, Kind.OTHER, (args) -> config.destDirName = args.get(0)));
+        this.options = new TreeSet<>(comparing(o -> o.getNames().get(0), String::compareTo));
 
-            // Our own options
-            add(new Option("-createPumlFiles", 0, Kind.STANDARD, (args) -> config.renderPumlFile = true));
-            add(new Option("-umlImageDirectory", 1, Kind.STANDARD, (args) -> config.images.directory = args.get(0)));
-            add(new Option("-umlImageFormat", 1, Kind.STANDARD, (args) -> config.images.addImageFormat(args.get(0))));
-            add(new Option("-umlEncoding", 1, Kind.STANDARD, (args) -> config.umlencoding = args.get(0)));
-            add(new Option("-umlExcludedPackageDependencies", 1, Kind.STANDARD,
-                    (args) -> config.excludedPackageDependencies = splitToList(args.get(0))));
-            add(new Option("-failOnCyclicPackageDependencies", 1, Kind.STANDARD,
-                    (args) -> config.failOnCyclicPackageDependencies = asBoolean(args.get(0))));
-        }};
+        // Options from Standard doclet that we also support
+        this.options.add(new Option("-quiet", 0, Kind.OTHER, (args) -> config.quiet = true));
+        this.options.add(new Option("-verbose", 0, Kind.OTHER, (args) -> config.verbose = true));
+        this.options.add(new Option("-docencoding", 1, Kind.OTHER, (args) -> config.docencoding = args.get(0)));
+        this.options.add(new Option("-encoding", 1, Kind.OTHER, (args) -> config.encoding = args.get(0)));
+        this.options.add(new Option("-link", 1, Kind.OTHER,
+                (args) -> config.externalLinks.add(new ExternalLink(config, args.get(0), args.get(0)))));
+        this.options.add(new Option("-linkoffline", 2, Kind.OTHER,
+                (args) -> config.externalLinks.add(new ExternalLink(config, args.get(0), args.get(1)))));
+        this.options.add(new Option("-private", 0, Kind.OTHER, (args) -> config.showMembers("private")));
+        this.options.add(new Option("-package", 0, Kind.OTHER, (args) -> config.showMembers("package")));
+        this.options.add(new Option("-protected", 0, Kind.OTHER, (args) -> config.showMembers("protected")));
+        this.options.add(new Option("-public", 0, Kind.OTHER, (args) -> config.showMembers("public")));
+        this.options.add(new Option("--show-members", 1, Kind.OTHER, (args) -> config.showMembers(args.get(0))));
+        this.options.add(new Option("-d", 1, Kind.OTHER, (args) -> config.destDirName = args.get(0)));
+
+        // Our own options
+        this.options.add(new Option("-createPumlFiles", 0, Kind.STANDARD, (args) -> config.renderPumlFile = true));
+        this.options.add(new Option("-umlImageDirectory", 1, Kind.STANDARD, (args) -> config.images.directory = args.get(0)));
+        this.options.add(new Option("-umlImageFormat", 1, Kind.STANDARD, (args) -> config.images.addImageFormat(args.get(0))));
+        this.options.add(new Option("-umlEncoding", 1, Kind.STANDARD, (args) -> config.umlencoding = args.get(0)));
+        this.options.add(new Option("-umlExcludedPackageDependencies", 1, Kind.STANDARD,
+                (args) -> config.excludedPackageDependencies = splitToList(args.get(0))));
+        this.options.add(new Option("-failOnCyclicPackageDependencies", 1, Kind.STANDARD,
+                (args) -> config.failOnCyclicPackageDependencies = asBoolean(args.get(0))));
+        this.options.add(new Option("-umlJavaBeanPropertiesAsFields", 0, Kind.STANDARD,
+                (args) -> config.methodConfig.javaBeanPropertiesAsFields = true));
     }
 
     Set<Doclet.Option> mergeWith(final Set<Doclet.Option> standardOptions) {

--- a/src/main/java/nl/talsmasoftware/umldoclet/uml/DependencyDiagram.java
+++ b/src/main/java/nl/talsmasoftware/umldoclet/uml/DependencyDiagram.java
@@ -34,10 +34,15 @@ public class DependencyDiagram extends Diagram {
 
     public void addPackageDependency(String fromPackage, String toPackage) {
         if (fromPackage != null && toPackage != null && !isExcludedPackage(toPackage)) {
-            if (fromPackage.isEmpty()) fromPackage = "unnamed";
-            if (toPackage.isEmpty()) toPackage = "unnamed";
-            addChild(new Reference(Side.from(fromPackage, null), "-->", Side.to(toPackage, null)));
+            this.addChild(new Reference(
+                    Side.from(unnamedIfEmpty(fromPackage), null),
+                    "-->",
+                    Side.to(unnamedIfEmpty(toPackage), null)));
         }
+    }
+
+    private static String unnamedIfEmpty(String packageName) {
+        return packageName.isEmpty() ? "unnamed" : packageName;
     }
 
     private boolean isExcludedPackage(String toPackage) {

--- a/src/main/java/nl/talsmasoftware/umldoclet/uml/Method.java
+++ b/src/main/java/nl/talsmasoftware/umldoclet/uml/Method.java
@@ -29,16 +29,26 @@ public class Method extends TypeMember {
         super(containingType, name, returnType);
     }
 
-    private Parameters getParameters() {
+    private Parameters getOrCreateParameters() {
         return getChildren().stream()
                 .filter(Parameters.class::isInstance).map(Parameters.class::cast)
                 .findFirst()
-                .orElseThrow(() -> new IllegalStateException("No method parameters found!")); // TODO: 'no parameters'?
+                .orElseGet(this::createAndAddNewParameters);
+    }
+
+    /**
+     * Add a new parameter to this method.
+     *
+     * @param name The name of the parameter.
+     * @param type The type of the parameter.
+     */
+    public void addParameter(String name, TypeName type) {
+        getOrCreateParameters().add(name, type);
     }
 
     @Override
     protected <IPW extends IndentingPrintWriter> IPW writeParametersTo(IPW output) {
-        return getParameters().writeTo(output);
+        return getOrCreateParameters().writeTo(output);
     }
 
     @Override
@@ -59,18 +69,24 @@ public class Method extends TypeMember {
     @Override
     void replaceParameterizedType(TypeName from, TypeName to) {
         super.replaceParameterizedType(from, to);
-        getParameters().replaceParameterizedType(from, to);
+        getOrCreateParameters().replaceParameterizedType(from, to);
+    }
+
+    private Parameters createAndAddNewParameters() {
+        Parameters parameters = new Parameters(this);
+        this.addChild(parameters);
+        return parameters;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), getParameters());
+        return Objects.hash(super.hashCode(), getOrCreateParameters());
     }
 
     @Override
     public boolean equals(Object other) {
         return super.equals(other)
-                && getParameters().equals(((Method) other).getParameters());
+                && getOrCreateParameters().equals(((Method) other).getOrCreateParameters());
     }
 
 }

--- a/src/main/java/nl/talsmasoftware/umldoclet/uml/Parameters.java
+++ b/src/main/java/nl/talsmasoftware/umldoclet/uml/Parameters.java
@@ -71,7 +71,7 @@ public class Parameters extends UMLNode {
         }
     }
 
-    private class Parameter extends UMLNode {
+    public class Parameter extends UMLNode {
         private final String name;
         private TypeName type;
 

--- a/src/main/java/nl/talsmasoftware/umldoclet/uml/Reference.java
+++ b/src/main/java/nl/talsmasoftware/umldoclet/uml/Reference.java
@@ -22,14 +22,11 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Objects;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptySet;
-import static java.util.Collections.singleton;
-import static java.util.Collections.unmodifiableCollection;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toCollection;
 
 /**
  * Reference between two types.
@@ -44,13 +41,12 @@ import static java.util.Objects.requireNonNull;
  * @author Sjoerd Talsma
  */
 public class Reference extends UMLNode {
-
     public final Side from, to;
     public final String type;
     public final Collection<String> notes;
 
     public Reference(Side from, String type, Side to, String... notes) {
-        this(from, type, to, notes != null && notes.length > 0 ? asList(notes) : null);
+        this(from, type, to, notes == null ? emptySet() : asList(notes));
     }
 
     private Reference(Side from, String type, Side to, Collection<String> notes) {
@@ -59,13 +55,10 @@ public class Reference extends UMLNode {
         this.type = requireNonNull(type, "Reference type is <null>.").trim();
         if (this.type.isEmpty()) throw new IllegalArgumentException("Reference type is empty.");
         this.to = requireNonNull(to, "Reference \"to\" side is <null>.");
-
-        notes = (notes == null ? Stream.<String>empty() : notes.stream()).filter(Objects::nonNull)
+        this.notes = notes.stream()
+                .filter(Objects::nonNull)
                 .map(String::trim).filter(s -> !s.isEmpty())
-                .collect(Collectors.toCollection(LinkedHashSet::new));
-        this.notes = notes.isEmpty() ? emptySet()
-                : notes.size() == 1 ? singleton(notes.iterator().next())
-                : unmodifiableCollection(notes);
+                .collect(toCollection(LinkedHashSet::new));
     }
 
     public boolean isSelfReference() {
@@ -161,7 +154,8 @@ public class Reference extends UMLNode {
 
     public static final class Side {
         private final boolean nameFirst;
-        private final String qualifiedName, cardinality;
+        private final String qualifiedName;
+        private final String cardinality;
 
         public static Side from(String qualifiedName, String cardinality) {
             return new Side(qualifiedName, cardinality, true);
@@ -173,9 +167,7 @@ public class Reference extends UMLNode {
 
         private Side(String qualifiedName, String cardinality, boolean nameFirst) {
             requireNonNull(qualifiedName, "Name of referred object is <null>.");
-            int genericIdx = qualifiedName.indexOf('<');
-            if (genericIdx > 0) qualifiedName = qualifiedName.substring(0, genericIdx);
-            this.qualifiedName = qualifiedName.trim();
+            this.qualifiedName = qualifiedName.substring(0, indexOrLengthOf(qualifiedName, '<')).trim();
             if (this.qualifiedName.isEmpty()) throw new IllegalArgumentException("Name of referred object is empty.");
             this.cardinality = cardinality == null ? "" : cardinality.trim();
             this.nameFirst = nameFirst;
@@ -211,6 +203,18 @@ public class Reference extends UMLNode {
         @Override
         public String toString() {
             return toString(null);
+        }
+
+        /**
+         * The index of the searched character or the length of the string if not found.
+         *
+         * @param value The string to search in
+         * @param ch    The character to search for
+         * @return The index of the character in the string or the length of the string if not found.
+         */
+        private static int indexOrLengthOf(String value, char ch) {
+            int idx = value.indexOf(ch);
+            return idx >= 0 ? idx : value.length();
         }
     }
 

--- a/src/main/java/nl/talsmasoftware/umldoclet/uml/TypeMember.java
+++ b/src/main/java/nl/talsmasoftware/umldoclet/uml/TypeMember.java
@@ -32,7 +32,9 @@ public abstract class TypeMember extends UMLNode {
     public final String name;
     public TypeName type;
     private Visibility visibility;
-    public boolean isAbstract, isStatic, isDeprecated;
+    public boolean isAbstract;
+    public boolean isStatic;
+    public boolean isDeprecated;
 
     protected TypeMember(Type containingType, String name, TypeName type) {
         super(containingType);

--- a/src/main/java/nl/talsmasoftware/umldoclet/uml/TypeMember.java
+++ b/src/main/java/nl/talsmasoftware/umldoclet/uml/TypeMember.java
@@ -30,7 +30,7 @@ import static java.util.Objects.requireNonNull;
 public abstract class TypeMember extends UMLNode {
 
     public final String name;
-    protected TypeName type;
+    public TypeName type;
     private Visibility visibility;
     public boolean isAbstract, isStatic, isDeprecated;
 

--- a/src/main/java/nl/talsmasoftware/umldoclet/uml/UMLNode.java
+++ b/src/main/java/nl/talsmasoftware/umldoclet/uml/UMLNode.java
@@ -22,7 +22,6 @@ import nl.talsmasoftware.umldoclet.rendering.indent.IndentingRenderer;
 
 import java.io.StringWriter;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Optional;
@@ -30,7 +29,9 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 import static java.util.Collections.newSetFromMap;
+import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
 
 /**
  * Smallest 'independent' part of an UML diagram that can be rendered,
@@ -69,7 +70,18 @@ public abstract class UMLNode implements IndentingRenderer {
     }
 
     public List<UMLNode> getChildren() {
-        return Collections.unmodifiableList(children);
+        return unmodifiableList(children);
+    }
+
+    /**
+     * Returns all children that are an instance of a particular type.
+     *
+     * @param type The type of {@code UMLNode} to return (required, non-null).
+     * @param <T>  The type of children to obtain.
+     * @return The filtered list of children of this uml node (unmodifiable).
+     */
+    public <T extends UMLNode> List<T> getChildren(Class<T> type) {
+        return unmodifiableList(children.stream().filter(type::isInstance).map(type::cast).collect(toList()));
     }
 
     public void addChild(UMLNode child) {

--- a/src/main/java/nl/talsmasoftware/umldoclet/uml/util/JavaBeanProperty.java
+++ b/src/main/java/nl/talsmasoftware/umldoclet/uml/util/JavaBeanProperty.java
@@ -50,7 +50,7 @@ class JavaBeanProperty {
     private Method getter;
     private Method setter;
 
-    JavaBeanProperty(String name) {
+    private JavaBeanProperty(String name) {
         this.name = name;
     }
 
@@ -138,7 +138,7 @@ class JavaBeanProperty {
         if (value != null && !value.isEmpty() && !isLowerCase(value.charAt(0))) {
             char[] chars = value.toCharArray();
             chars[0] = toLowerCase(chars[0]);
-            value = new String(chars);
+            return new String(chars);
         }
         return value;
     }

--- a/src/main/java/nl/talsmasoftware/umldoclet/uml/util/JavaBeanProperty.java
+++ b/src/main/java/nl/talsmasoftware/umldoclet/uml/util/JavaBeanProperty.java
@@ -101,14 +101,18 @@ class JavaBeanProperty {
      * is <strong>not</strong>> considered thread-safe!
      */
     void replaceGetterAndSetterByField() {
-        if (field == null && getter != null && setter != null) {
+        if (getter != null && setter != null) {
             // Convert the getter into a field for UML rendering purposes.
             final Type type = (Type) getter.getParent();
             field = new Field(type, name, getter.type);
             field.setVisibility(getter.getVisibility());
-            type.removeChildren(child -> getter.equals(child) || setter.equals(child));
+            type.removeChildren(this::isSameProperty);
             type.addChild(field);
         }
+    }
+
+    private boolean isSameProperty(UMLNode node) {
+        return node instanceof TypeMember && propertyNameOf((TypeMember) node).filter(name::equals).isPresent();
     }
 
     /**

--- a/src/main/java/nl/talsmasoftware/umldoclet/uml/util/JavaBeanProperty.java
+++ b/src/main/java/nl/talsmasoftware/umldoclet/uml/util/JavaBeanProperty.java
@@ -174,8 +174,10 @@ public class JavaBeanProperty {
     private static Optional<String> propertyNameOfAccessor(Method method) {
         Optional<String> propertyName = Optional.empty();
         if (isGetterMethod(method) || isSetterMethod(method)) {
+            // Method name without 'get' / 'set' decapitalized
             propertyName = Optional.of(decapitalize(method.name.substring(3)));
-        } else if (method.name.startsWith("is") && isBooleanType(method.type) && parameterCount(method) == 0) {
+        } else if (isBooleanGetterMethod(method)) {
+            // Method name without 'is' decapitalized
             propertyName = Optional.of(decapitalize(method.name.substring(2)));
         }
         return propertyName;
@@ -183,6 +185,10 @@ public class JavaBeanProperty {
 
     private static boolean isGetterMethod(Method method) {
         return method.type != null && method.name.startsWith("get") && parameterCount(method) == 0;
+    }
+
+    private static boolean isBooleanGetterMethod(Method method) {
+        return isBooleanType(method.type) && method.name.startsWith("is") && parameterCount(method) == 0;
     }
 
     private static boolean isSetterMethod(Method method) {

--- a/src/main/java/nl/talsmasoftware/umldoclet/uml/util/JavaBeanProperty.java
+++ b/src/main/java/nl/talsmasoftware/umldoclet/uml/util/JavaBeanProperty.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2016-2019 Talsma ICT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.talsmasoftware.umldoclet.uml.util;
+
+import nl.talsmasoftware.umldoclet.uml.Field;
+import nl.talsmasoftware.umldoclet.uml.Method;
+import nl.talsmasoftware.umldoclet.uml.Parameters;
+import nl.talsmasoftware.umldoclet.uml.Type;
+import nl.talsmasoftware.umldoclet.uml.TypeMember;
+import nl.talsmasoftware.umldoclet.uml.TypeName;
+import nl.talsmasoftware.umldoclet.uml.UMLNode;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.lang.Character.isLowerCase;
+import static java.lang.Character.toLowerCase;
+import static java.util.Collections.emptySet;
+
+/**
+ * Class representing a property of a Java Bean.
+ *
+ * <p>
+ * Each java bean contains properties that have getter and setter methods allowing access to a single field.
+ *
+ * <p>
+ * Also see: <a href="https://en.wikipedia.org/wiki/JavaBeans">JavaBeans definition on Wikipedia</a>
+ * or the <a href="http://www.oracle.com/technetwork/java/javase/documentation/spec-136004.html">Official
+ * JavaBeans 1.01 Specification</a>.
+ */
+class JavaBeanProperty {
+    private final String name;
+
+    private Field field;
+    private Method getter;
+    private Method setter;
+
+    JavaBeanProperty(String name) {
+        this.name = name;
+    }
+
+    static Collection<JavaBeanProperty> detectFrom(Type type) {
+        if (type == null) return emptySet();
+        final Map<String, JavaBeanProperty> byName = new LinkedHashMap<>();
+        type.getChildren().stream()
+                .filter(TypeMember.class::isInstance).map(TypeMember.class::cast)
+                .forEach(typeMember ->
+                        propertyNameOf(typeMember).ifPresent(propertyName ->
+                                byName.computeIfAbsent(propertyName, JavaBeanProperty::new)
+                                        .add(typeMember)));
+        return byName.values();
+    }
+
+    private static Optional<String> propertyNameOf(TypeMember member) {
+        if (member instanceof Field) {
+            return Optional.of(member.name);
+        } else if (member instanceof Method) {
+            if (member.name.startsWith("get") && member.type != null && parameterCount(member) == 0) {
+                return Optional.of(decapitalize(member.name.substring(3)));
+            } else if (member.name.startsWith("is") && isBooleanType(member.type) && parameterCount(member) == 0) {
+                return Optional.of(decapitalize(member.name.substring(2)));
+            } else if (member.name.startsWith("set") && parameterCount(member) == 1) {
+                return Optional.of(decapitalize(member.name.substring(3)));
+            }
+        }
+        return Optional.empty();
+    }
+
+    private void add(TypeMember member) {
+        if (member instanceof Field) {
+            this.field = (Field) member;
+        } else if (member instanceof Method) {
+            if (member.name.startsWith("set")) {
+                this.setter = (Method) member;
+            } else {
+                this.getter = (Method) member;
+            }
+        }
+    }
+
+    /**
+     * Remove the getter and setter methods from the parent and replace them with a field.
+     *
+     * <p>
+     * <strong>Note:</strong> this method modifies the {@linkplain Type} parent in-place and therefore
+     * is <strong>not</strong>> considered thread-safe!
+     */
+    void replaceGetterAndSetterByField() {
+        if (field == null && getter != null && setter != null) {
+            // Convert the getter into a field for UML rendering purposes.
+            final Type type = (Type) getter.getParent();
+            field = new Field(type, name, getter.type);
+            field.setVisibility(getter.getVisibility());
+            type.removeChildren(child -> getter.equals(child) || setter.equals(child));
+            type.addChild(field);
+        }
+    }
+
+    /**
+     * Counts the parameters of a typemember.
+     *
+     * @param member The type member to count the parameters of.
+     * @return The total number of children in {@code Parameters} children of the member.
+     */
+    private static int parameterCount(TypeMember member) {
+        return member.getChildren().stream()
+                .filter(Parameters.class::isInstance)
+                .map(UMLNode::getChildren).mapToInt(Collection::size)
+                .sum();
+    }
+
+    /**
+     * Changes the first character of the string into a lowercase character.
+     *
+     * @param value The value to decapitalize.
+     * @return The decapitalized value.
+     */
+    private static String decapitalize(String value) {
+        if (value != null && !value.isEmpty() && !isLowerCase(value.charAt(0))) {
+            char[] chars = value.toCharArray();
+            chars[0] = toLowerCase(chars[0]);
+            value = new String(chars);
+        }
+        return value;
+    }
+
+    /**
+     * Determines whether the type is a boolean type.
+     *
+     * <p>
+     * This should be either the primitive {@code boolean} or the {@code java.lang.Boolean} wrapper.
+     *
+     * @param type The type to check if it represents a boolean.
+     * @return {@code true} if the type is a boolean type, otherwise {@code false}.
+     */
+    private static boolean isBooleanType(TypeName type) {
+        return type != null && ("boolean".equals(type.qualified) || "java.lang.Boolean".equals(type.qualified));
+    }
+
+}

--- a/src/main/java/nl/talsmasoftware/umldoclet/uml/util/UmlPostProcessors.java
+++ b/src/main/java/nl/talsmasoftware/umldoclet/uml/util/UmlPostProcessors.java
@@ -22,9 +22,16 @@ import java.util.function.Consumer;
 /**
  * Utility class providing postprocessing functionality for generated UML models.
  */
-public final class UmlPostProcessors {
+public class UmlPostProcessors {
 
-    public static Consumer<Type> javaBeanPropertiesAsFieldsPostProcessor() {
+    /**
+     * A post-processor for a uml {@linkplain Type} to replace getter and setter
+     * {@linkplain nl.talsmasoftware.umldoclet.uml.Method methods}
+     * into {@linkplain nl.talsmasoftware.umldoclet.uml.Field fields}.
+     *
+     * @return The postprocessor that updates types.
+     */
+    public Consumer<Type> javaBeanPropertiesAsFieldsPostProcessor() {
         return type -> JavaBeanProperty.detectFrom(type).forEach(JavaBeanProperty::replaceGetterAndSetterByField);
     }
 

--- a/src/main/java/nl/talsmasoftware/umldoclet/uml/util/UmlPostProcessors.java
+++ b/src/main/java/nl/talsmasoftware/umldoclet/uml/util/UmlPostProcessors.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016-2019 Talsma ICT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.talsmasoftware.umldoclet.uml.util;
+
+import nl.talsmasoftware.umldoclet.uml.Type;
+
+import java.util.function.Consumer;
+
+/**
+ * Utility class providing postprocessing functionality for generated UML models.
+ */
+public final class UmlPostProcessors {
+
+    public static Consumer<Type> javaBeanPropertiesAsFieldsPostProcessor() {
+        return type -> JavaBeanProperty.detectFrom(type).forEach(JavaBeanProperty::replaceGetterAndSetterByField);
+    }
+
+}

--- a/src/main/resources/nl/talsmasoftware/umldoclet/UMLDoclet.properties
+++ b/src/main/resources/nl/talsmasoftware/umldoclet/UMLDoclet.properties
@@ -2,6 +2,7 @@
 build.timestamp=${build.timestamp}
 build.revision=${git.revision}
 doclet.version=${project.version}
+
 # Messages
 doclet.copyright=UML Doclet (C) Copyright Talsma ICT, version: {0}.
 doclet.uml.footer=UMLDoclet {0}, PlantUML {1}
@@ -22,6 +23,7 @@ warning.package.dependency.cycles=One or more cyclic package dependencies detect
 error.unanticipated.error.generating.uml=Unanticipated error generating UML: {0}
 error.unanticipated.error.generating.diagrams=Unanticipated error generating diagrams: {0}
 error.unanticipated.error.postprocessing.html=Unanticipated error post-processing HTML: {0}
+
 # Usage
 doclet.usage.createpumlfiles.description=Create PlantUML '.puml' files
 doclet.usage.umlimagedirectory.description=Custom directory for UML diagram images
@@ -34,3 +36,4 @@ doclet.usage.umlexcludedpackagedependencies.description=Packages excluded from U
 doclet.usage.umlexcludedpackagedependencies.parameters=<package>(,<package>)*
 doclet.usage.failoncyclicpackagedependencies.description=Fail on cyclic package dependencies (defaults to false)
 doclet.usage.failoncyclicpackagedependencies.parameters=(true|false)
+doclet.usage.umljavabeanpropertiesasfields.description=To render JavaBean getters and setters as fields in UML

--- a/src/test/java/nl/talsmasoftware/umldoclet/features/Issue124PropertiesAsFieldsTest.java
+++ b/src/test/java/nl/talsmasoftware/umldoclet/features/Issue124PropertiesAsFieldsTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016-2019 Talsma ICT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.talsmasoftware.umldoclet.features;
+
+import nl.talsmasoftware.umldoclet.UMLDoclet;
+import nl.talsmasoftware.umldoclet.features.beans.StandardBean;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.spi.ToolProvider;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Test that properties can be rendered as fields with the option {@code -umlPropertiesAsFields true}.
+ */
+public class Issue124PropertiesAsFieldsTest {
+    private static final File outputdir = new File("target/issues/124");
+
+    @Test
+    public void testPropertiesAsFieldsForPublicClass() {
+        assertThat("Javadoc result", ToolProvider.findFirst("javadoc").get().run(
+                System.out, System.err,
+                "-d", outputdir.getPath(),
+                "-sourcepath", "src/test/java",
+                "-doclet", UMLDoclet.class.getName(),
+                "-quiet", "-createPumlFiles",
+//                "-umlPropertiesAsFields", "true",
+                StandardBean.class.getPackageName()
+        ), is(0));
+
+    }
+
+
+}

--- a/src/test/java/nl/talsmasoftware/umldoclet/features/Issue124PropertiesAsFieldsTest.java
+++ b/src/test/java/nl/talsmasoftware/umldoclet/features/Issue124PropertiesAsFieldsTest.java
@@ -17,6 +17,7 @@ package nl.talsmasoftware.umldoclet.features;
 
 import nl.talsmasoftware.umldoclet.UMLDoclet;
 import nl.talsmasoftware.umldoclet.features.beans.StandardJavaBean;
+import nl.talsmasoftware.umldoclet.util.Testing;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -24,7 +25,9 @@ import java.io.File;
 import java.util.spi.ToolProvider;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 
 /**
  * Test that properties can be rendered as fields with the option {@code -umlPropertiesAsFields true}.
@@ -47,7 +50,21 @@ public class Issue124PropertiesAsFieldsTest {
 
     @Test
     public void testPropertiesAsFieldsForPublicClass() {
+        String umlFileName = StandardJavaBean.class.getName().replace('.', '/') + ".puml";
+        String uml = Testing.read(new File(outputdir, umlFileName));
+        assertThat(uml, containsString("+stringValue: String"));
+        assertThat(uml, containsString("+intValue: int"));
+        assertThat(uml, containsString("+booleanValue: boolean"));
+        assertThat(uml, containsString("+child: StandardJavaBean"));
 
+        assertThat(uml, not(containsString("getStringValue(")));
+        assertThat(uml, not(containsString("setStringValue(")));
+        assertThat(uml, not(containsString("getIntValue(")));
+        assertThat(uml, not(containsString("setIntValue(")));
+        assertThat(uml, not(containsString("isBooleanValue(")));
+        assertThat(uml, not(containsString("setBooleanValue(")));
+        assertThat(uml, not(containsString("getChild(")));
+        assertThat(uml, not(containsString("setChild(")));
     }
 
 

--- a/src/test/java/nl/talsmasoftware/umldoclet/features/Issue124PropertiesAsFieldsTest.java
+++ b/src/test/java/nl/talsmasoftware/umldoclet/features/Issue124PropertiesAsFieldsTest.java
@@ -67,5 +67,23 @@ public class Issue124PropertiesAsFieldsTest {
         assertThat(uml, not(containsString("setChild(")));
     }
 
+    @Test
+    public void testPropertiesAsFieldsForPackageDiagram() {
+        String umlFileName = StandardJavaBean.class.getPackageName().replace('.', '/') + "/package.puml";
+        String uml = Testing.read(new File(outputdir, umlFileName));
+        assertThat(uml, containsString("+stringValue: String"));
+        assertThat(uml, containsString("+intValue: int"));
+        assertThat(uml, containsString("+booleanValue: boolean"));
+        assertThat(uml, containsString("StandardJavaBean --> StandardJavaBean: child"));
+
+        assertThat(uml, not(containsString("getStringValue(")));
+        assertThat(uml, not(containsString("setStringValue(")));
+        assertThat(uml, not(containsString("getIntValue(")));
+        assertThat(uml, not(containsString("setIntValue(")));
+        assertThat(uml, not(containsString("isBooleanValue(")));
+        assertThat(uml, not(containsString("setBooleanValue(")));
+        assertThat(uml, not(containsString("getChild(")));
+        assertThat(uml, not(containsString("setChild(")));
+    }
 
 }

--- a/src/test/java/nl/talsmasoftware/umldoclet/features/Issue124PropertiesAsFieldsTest.java
+++ b/src/test/java/nl/talsmasoftware/umldoclet/features/Issue124PropertiesAsFieldsTest.java
@@ -16,7 +16,8 @@
 package nl.talsmasoftware.umldoclet.features;
 
 import nl.talsmasoftware.umldoclet.UMLDoclet;
-import nl.talsmasoftware.umldoclet.features.beans.StandardBean;
+import nl.talsmasoftware.umldoclet.features.beans.StandardJavaBean;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.File;
@@ -31,17 +32,21 @@ import static org.hamcrest.Matchers.is;
 public class Issue124PropertiesAsFieldsTest {
     private static final File outputdir = new File("target/issues/124");
 
-    @Test
-    public void testPropertiesAsFieldsForPublicClass() {
+    @BeforeClass
+    public static void generateBeansPackageJavadoc() {
         assertThat("Javadoc result", ToolProvider.findFirst("javadoc").get().run(
                 System.out, System.err,
                 "-d", outputdir.getPath(),
                 "-sourcepath", "src/test/java",
                 "-doclet", UMLDoclet.class.getName(),
                 "-quiet", "-createPumlFiles",
-//                "-umlPropertiesAsFields", "true",
-                StandardBean.class.getPackageName()
+                "-umlJavaBeanPropertiesAsFields",
+                StandardJavaBean.class.getPackageName()
         ), is(0));
+    }
+
+    @Test
+    public void testPropertiesAsFieldsForPublicClass() {
 
     }
 

--- a/src/test/java/nl/talsmasoftware/umldoclet/features/Issue148StandardIncludeOptionsTest.java
+++ b/src/test/java/nl/talsmasoftware/umldoclet/features/Issue148StandardIncludeOptionsTest.java
@@ -113,7 +113,6 @@ public class Issue148StandardIncludeOptionsTest {
         assertThat(privateClassUml, containsString("~getPackageProtectedValue()"));
         assertThat(privateClassUml, containsString("#getProtectedValue()"));
         assertThat(privateClassUml, containsString("+getPublicValue()"));
-
     }
 
     @Test

--- a/src/test/java/nl/talsmasoftware/umldoclet/features/PublicClass.java
+++ b/src/test/java/nl/talsmasoftware/umldoclet/features/PublicClass.java
@@ -15,6 +15,7 @@
  */
 package nl.talsmasoftware.umldoclet.features;
 
+@SuppressWarnings("unused") // used for testing generated UML code
 public class PublicClass {
     private String privateField;
     String packageProtectedField;

--- a/src/test/java/nl/talsmasoftware/umldoclet/features/beans/StandardBean.java
+++ b/src/test/java/nl/talsmasoftware/umldoclet/features/beans/StandardBean.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016-2019 Talsma ICT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.talsmasoftware.umldoclet.features.beans;
+
+public class StandardBean {
+
+    private String stringValue;
+    private int intValue;
+    private boolean booleanValue;
+
+    public String getStringValue() {
+        return stringValue;
+    }
+
+    public void setStringValue(String stringValue) {
+        this.stringValue = stringValue;
+    }
+
+    public int getIntValue() {
+        return intValue;
+    }
+
+    public void setIntValue(int intValue) {
+        this.intValue = intValue;
+    }
+
+    public boolean isBooleanValue() {
+        return booleanValue;
+    }
+
+    public void setBooleanValue(boolean booleanValue) {
+        this.booleanValue = booleanValue;
+    }
+
+}

--- a/src/test/java/nl/talsmasoftware/umldoclet/features/beans/StandardJavaBean.java
+++ b/src/test/java/nl/talsmasoftware/umldoclet/features/beans/StandardJavaBean.java
@@ -15,11 +15,12 @@
  */
 package nl.talsmasoftware.umldoclet.features.beans;
 
-public class StandardBean {
+public class StandardJavaBean {
 
     private String stringValue;
     private int intValue;
     private boolean booleanValue;
+    private StandardJavaBean child;
 
     public String getStringValue() {
         return stringValue;
@@ -43,6 +44,14 @@ public class StandardBean {
 
     public void setBooleanValue(boolean booleanValue) {
         this.booleanValue = booleanValue;
+    }
+
+    public StandardJavaBean getChild() {
+        return child;
+    }
+
+    public void setChild(StandardJavaBean child) {
+        this.child = child;
     }
 
 }

--- a/src/test/java/nl/talsmasoftware/umldoclet/issues/Issue71DeprecationTest.java
+++ b/src/test/java/nl/talsmasoftware/umldoclet/issues/Issue71DeprecationTest.java
@@ -112,7 +112,7 @@ public class Issue71DeprecationTest {
     }
 
     @Test
-    public void testIssue73_innerClassImageName() {
+    public void testIssue73InnerClassImageName() {
         File innerClassFile = new File(outputDir, "nl/talsmasoftware/umldoclet/issues/Issue71DeprecationTest.MoreDeprecation.svg");
         assertThat(innerClassFile + " exists?", innerClassFile.exists(), is(true));
     }
@@ -128,6 +128,7 @@ public class Issue71DeprecationTest {
             this(null);
         }
 
+        @SuppressWarnings("unused") // Used to test generated UML
         @Deprecated
         public MoreDeprecation(String ignored) {
         }

--- a/src/test/java/nl/talsmasoftware/umldoclet/issues/bug146/Bug146SkipSuperclassTest.java
+++ b/src/test/java/nl/talsmasoftware/umldoclet/issues/bug146/Bug146SkipSuperclassTest.java
@@ -31,7 +31,8 @@ import static org.hamcrest.Matchers.not;
 public class Bug146SkipSuperclassTest {
     private static final String packageAsPath = Bug146SkipSuperclassTest.class.getPackageName().replace('.', '/');
     private static final File outputdir = new File("target/issues/146");
-    private static String classUml, packageUml;
+    private static String classUml;
+    private static String packageUml;
 
     @BeforeClass
     public static void generateJavadoc() {

--- a/src/test/java/nl/talsmasoftware/umldoclet/javadoc/DocletConfigTest.java
+++ b/src/test/java/nl/talsmasoftware/umldoclet/javadoc/DocletConfigTest.java
@@ -31,6 +31,8 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 
 /**
+ * Tests the Doclet Config parsing.
+ *
  * @author Sjoerd Talsma
  */
 public class DocletConfigTest {
@@ -57,6 +59,13 @@ public class DocletConfigTest {
         }
     }
 
+    /**
+     * Tests whether there were any undocumented options added to the doclet.
+     *
+     * <p>
+     * Please add documentation for the new option(s)
+     * in the {@code nl.talsmasoftware.umldoclet.UMLDoclet} resource bundle.
+     */
     @Test
     public void testForUndocumentedMissingKeys() {
         assertThat(getDocletHelpOutput(), not(containsString("<MISSING KEY>")));

--- a/src/test/java/nl/talsmasoftware/umldoclet/uml/util/UmlPostProcessorsTest.java
+++ b/src/test/java/nl/talsmasoftware/umldoclet/uml/util/UmlPostProcessorsTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2016-2019 Talsma ICT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.talsmasoftware.umldoclet.uml.util;
+
+import nl.talsmasoftware.umldoclet.uml.Field;
+import nl.talsmasoftware.umldoclet.uml.Method;
+import nl.talsmasoftware.umldoclet.uml.Namespace;
+import nl.talsmasoftware.umldoclet.uml.Type;
+import nl.talsmasoftware.umldoclet.uml.Type.Classification;
+import nl.talsmasoftware.umldoclet.uml.TypeName;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+public class UmlPostProcessorsTest {
+    private static final Namespace UNNAMED = new Namespace(null, "");
+
+    @Test
+    public void testJavaBeanPropertiesAsFieldsPostProcessorAcceptsNull() {
+        UmlPostProcessors.javaBeanPropertiesAsFieldsPostProcessor().accept(null);
+    }
+
+    @Test
+    public void testJavaBeanPropertiesAsFieldsPostProcessorAcceptsEmptyType() {
+        Type emptyType = new Type(UNNAMED, Classification.CLASS, typeName("EmptyType"));
+        UmlPostProcessors.javaBeanPropertiesAsFieldsPostProcessor().accept(emptyType);
+        assertThat(emptyType.getPackagename(), equalTo(""));
+        assertThat(emptyType.getClassfication(), is(Classification.CLASS));
+        assertThat(emptyType.getName(), equalTo(typeName("EmptyType")));
+        assertThat(emptyType.getChildren(), is(empty()));
+    }
+
+    @Test
+    public void testJavaBeanPropertiesAsFielsPostProcessorSimpleAccessors() {
+        Type simpleBean = new Type(UNNAMED, Classification.CLASS, typeName("SimpleBean"));
+        Method getter = new Method(simpleBean, "getStringValue", typeName("java.lang.String"));
+        Method setter = new Method(simpleBean, "setStringValue", null);
+        setter.addParameter("stringValue", typeName("java.lang.String"));
+        simpleBean.addChild(getter);
+        simpleBean.addChild(setter);
+
+        UmlPostProcessors.javaBeanPropertiesAsFieldsPostProcessor().accept(simpleBean);
+        assertThat(simpleBean.getChildren(), hasSize(1));
+        assertThat(simpleBean.getChildren().get(0), instanceOf(Field.class));
+    }
+
+    private static TypeName typeName(String qualified) {
+        int lastDot = qualified.lastIndexOf('.');
+        String simpleName = lastDot >= 0 ? qualified.substring(lastDot + 1) : qualified;
+        return new TypeName(simpleName, qualified);
+    }
+}

--- a/src/test/java/nl/talsmasoftware/umldoclet/uml/util/UmlPostProcessorsTest.java
+++ b/src/test/java/nl/talsmasoftware/umldoclet/uml/util/UmlPostProcessorsTest.java
@@ -21,6 +21,7 @@ import nl.talsmasoftware.umldoclet.uml.Namespace;
 import nl.talsmasoftware.umldoclet.uml.Type;
 import nl.talsmasoftware.umldoclet.uml.Type.Classification;
 import nl.talsmasoftware.umldoclet.uml.TypeName;
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -29,19 +30,31 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
 
 public class UmlPostProcessorsTest {
     private static final Namespace UNNAMED = new Namespace(null, "");
 
+    private UmlPostProcessors postProcessors;
+
+    @Before
+    public void initializePostprocessors() {
+        postProcessors = new UmlPostProcessors();
+    }
+
     @Test
     public void testJavaBeanPropertiesAsFieldsPostProcessorAcceptsNull() {
-        UmlPostProcessors.javaBeanPropertiesAsFieldsPostProcessor().accept(null);
+        try {
+            postProcessors.javaBeanPropertiesAsFieldsPostProcessor().accept(null);
+        } catch (NullPointerException npe) {
+            fail("postprocessor should just accept null.");
+        }
     }
 
     @Test
     public void testJavaBeanPropertiesAsFieldsPostProcessorAcceptsEmptyType() {
         Type emptyType = new Type(UNNAMED, Classification.CLASS, typeName("EmptyType"));
-        UmlPostProcessors.javaBeanPropertiesAsFieldsPostProcessor().accept(emptyType);
+        postProcessors.javaBeanPropertiesAsFieldsPostProcessor().accept(emptyType);
         assertThat(emptyType.getPackagename(), equalTo(""));
         assertThat(emptyType.getClassfication(), is(Classification.CLASS));
         assertThat(emptyType.getName(), equalTo(typeName("EmptyType")));
@@ -57,7 +70,7 @@ public class UmlPostProcessorsTest {
         simpleBean.addChild(getter);
         simpleBean.addChild(setter);
 
-        UmlPostProcessors.javaBeanPropertiesAsFieldsPostProcessor().accept(simpleBean);
+        postProcessors.javaBeanPropertiesAsFieldsPostProcessor().accept(simpleBean);
         assertThat(simpleBean.getChildren(), hasSize(1));
         assertThat(simpleBean.getChildren().get(0), instanceOf(Field.class));
     }

--- a/src/test/java/nl/talsmasoftware/umldoclet/uml/util/UmlPostProcessorsTest.java
+++ b/src/test/java/nl/talsmasoftware/umldoclet/uml/util/UmlPostProcessorsTest.java
@@ -28,7 +28,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.fail;
 
@@ -64,15 +63,22 @@ public class UmlPostProcessorsTest {
     @Test
     public void testJavaBeanPropertiesAsFielsPostProcessorSimpleAccessors() {
         Type simpleBean = new Type(UNNAMED, Classification.CLASS, typeName("SimpleBean"));
+        Method businessMethod = new Method(simpleBean, "someBusinessMethod", null);
         Method getter = new Method(simpleBean, "getStringValue", typeName("java.lang.String"));
         Method setter = new Method(simpleBean, "setStringValue", null);
-        setter.addParameter("stringValue", typeName("java.lang.String"));
+        setter.addParameter("value", typeName("java.lang.String"));
         simpleBean.addChild(getter);
         simpleBean.addChild(setter);
+        simpleBean.addChild(businessMethod);
+
+        assertThat(simpleBean.getChildren(Method.class), hasSize(3));
+        assertThat(simpleBean.getChildren(Field.class), is(empty()));
 
         postProcessors.javaBeanPropertiesAsFieldsPostProcessor().accept(simpleBean);
-        assertThat(simpleBean.getChildren(), hasSize(1));
-        assertThat(simpleBean.getChildren().get(0), instanceOf(Field.class));
+        assertThat(simpleBean.getChildren(Method.class), hasSize(1));
+        assertThat(simpleBean.getChildren(Method.class).get(0).name, equalTo("someBusinessMethod"));
+        assertThat(simpleBean.getChildren(Field.class), hasSize(1));
+        assertThat(simpleBean.getChildren(Field.class).get(0).name, equalTo("stringValue"));
     }
 
     private static TypeName typeName(String qualified) {


### PR DESCRIPTION
Implemented by adding a `-umlJavaBeanPropertiesAsFields` commandline option which replaces all `Xyz` properties that have `getXyz()` and `setXyz(xyz)` methods with a `xyz` Field.

This fixes #124 