### PR TITLE
Remove LGTM badging

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,6 @@
 # UMLDoclet
 
 [![Codacy Badge][codacy-img]][codacy]
-[![LGTM Status][lgtm-img]][lgtm]
 [![Coverage Status][coveralls-img]][coveralls]
 
 Doclet for the JavaDoc tool that generates UML diagrams from the code.  


### PR DESCRIPTION
It seems LGTM cannot handle multi-module maven projects that require different JDK versions, so we'll have to disable it's integration for the moment.