### PR TITLE
Add javadoc again

### DIFF
--- a/java-8/pom.xml
+++ b/java-8/pom.xml
@@ -30,7 +30,7 @@
     <!-- Artifact identification -->
     <artifactId>umldoclet-java8</artifactId>
     <packaging>jar</packaging>
-    <name>UML doclet (java 8)</name>
+    <name>UML Doclet (java 8)</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/java-9/pom.xml
+++ b/java-9/pom.xml
@@ -37,6 +37,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>9</maven.compiler.release>
         <root.basedir>${project.parent.basedir}</root.basedir>
+        <java8.classes>${project.basedir}/../java-8/target/classes</java8.classes>
     </properties>
 
     <build>
@@ -73,7 +74,7 @@
                         <configuration>
                             <target>
                                 <copy todir="${project.build.directory}/classes-mr" preservelastmodified="true">
-                                    <fileset dir="${project.basedir}/../java-8/target/classes">
+                                    <fileset dir="${java8.classes}">
                                         <include name="**/*"/>
                                     </fileset>
                                 </copy>
@@ -83,6 +84,25 @@
                                     </fileset>
                                 </copy>
                             </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <jdkToolchain>
+                                <version>9</version>
+                            </jdkToolchain>
+                            <includeDependencySources>true</includeDependencySources>
+                            <docletPath>${build.outputDirectory}:${java8.classes}</docletPath>
+                            <doclet>nl.talsmasoftware.umldoclet.UMLDoclet</doclet>
                         </configuration>
                     </execution>
                 </executions>
@@ -144,33 +164,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <profiles>
-        <profile>
-            <id>release</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                                <configuration>
-                                    <jdkToolchain>
-                                        <version>9</version>
-                                    </jdkToolchain>
-                                    <includeDependencySources>true</includeDependencySources>
-                                    <docletPath>${build.outputDirectory}:${project.basedir}/../java-8/target/classes</docletPath>
-                                    <doclet>nl.talsmasoftware.umldoclet.UMLDoclet</doclet>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/java-9/pom.xml
+++ b/java-9/pom.xml
@@ -31,7 +31,7 @@
     <groupId>nl.talsmasoftware</groupId>
     <artifactId>umldoclet</artifactId>
     <packaging>jar</packaging>
-    <name>UML doclet (multi-release)</name>
+    <name>UML Doclet</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -145,4 +145,32 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                                <configuration>
+                                    <jdkToolchain>
+                                        <version>9</version>
+                                    </jdkToolchain>
+                                    <includeDependencySources>true</includeDependencySources>
+                                    <docletPath>${build.outputDirectory}:${project.basedir}/../java-8/target/classes</docletPath>
+                                    <doclet>nl.talsmasoftware.umldoclet.UMLDoclet</doclet>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,8 @@
     <packaging>pom</packaging>
 
     <!-- Project information -->
-    <name>Root - UML doclet</name>
-    <description>Javadoc StandardDoclet extension to include generated UML diagrams in the documentation.</description>
+    <name>Root - UML Doclet</name>
+    <description>Javadoc extension to generate and include UML diagrams in the standard documentation.</description>
     <url>https://github.com/talsma-ict/umldoclet</url>
     <inceptionYear>2016</inceptionYear>
 


### PR DESCRIPTION
The multi-release project now gets (v9) javadoc created with the java-9 doclet.
There are errors however, which won't allow us to use openjdk 13 yet.

This pull request fixes #213 