### PR TITLE
Improvement; use actual built jar for our own javadoc

### DIFF
--- a/java-9/pom.xml
+++ b/java-9/pom.xml
@@ -101,7 +101,7 @@
                                 <version>9</version>
                             </jdkToolchain>
                             <includeDependencySources>true</includeDependencySources>
-                            <docletPath>${project.build.outputDirectory}:${java8.classes}</docletPath>
+                            <docletPath>${project.build.directory}/${project.build.finalName}.jar</docletPath>
                             <doclet>nl.talsmasoftware.umldoclet.UMLDoclet</doclet>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,11 @@
                     <version>2.22.2</version>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>2.22.2</version>
+                </plugin>
+                <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
                     <version>0.8.5</version>


### PR DESCRIPTION
This is how I found out that multi-release doclet jars don't work 😞  ..

