### PR TITLE
Simplify build to use single LTS JDK version

### DIFF
--- a/.github/mvn-toolchains.xml
+++ b/.github/mvn-toolchains.xml
@@ -5,24 +5,6 @@
     <toolchain>
         <type>jdk</type>
         <provides>
-            <version>1.8</version>
-        </provides>
-        <configuration>
-            <jdkHome>${env.JAVA_8_HOME}</jdkHome>
-        </configuration>
-    </toolchain>
-    <toolchain>
-        <type>jdk</type>
-        <provides>
-            <version>11</version>
-        </provides>
-        <configuration>
-            <jdkHome>${env.JAVA_11_HOME}</jdkHome>
-        </configuration>
-    </toolchain>
-    <toolchain>
-        <type>jdk</type>
-        <provides>
             <version>17</version>
         </provides>
         <configuration>

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -27,16 +27,6 @@ jobs:
           GPG_OWNERTRUST: ${{ secrets.GPG_OWNERTRUST }}
       - name: Setup Graphviz
         run: sudo apt-get install graphviz
-      - name: Set up JDK 8 for compiling Java 5 compatible bytecode
-        id: setup-java-8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-      - name: Set up JDK 11
-        id: setup-java-11
-        uses: actions/setup-java@v1
-        with:
-          java-version: 11
       - name: Set up JDK 17
         id: setup-java-17
         uses: actions/setup-java@v1
@@ -52,8 +42,6 @@ jobs:
         run: .github/scripts/build.sh
         shell: bash
         env:
-          JAVA_8_HOME: ${{ steps.setup-java-8.outputs.path }}
-          JAVA_11_HOME: ${{ steps.setup-java-11.outputs.path }}
           JAVA_17_HOME: ${{ steps.setup-java-17.outputs.path }}
           MAVEN_CLI_OPTS: --settings .github/mvn-settings.xml --global-toolchains .github/mvn-toolchains.xml
           GPG_EXECUTABLE: /usr/bin/gpg
@@ -89,7 +77,7 @@ jobs:
         if: env.GH_TOKEN != null
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: 17
       - name: Set up maven cache
         if: env.GH_TOKEN != null
         uses: actions/cache@v2

--- a/pom.xml
+++ b/pom.xml
@@ -137,10 +137,11 @@
                 <version>${license-maven-plugin.version}</version>
                 <executions>
                     <execution>
+                        <id>check-license-headers</id>
+                        <phase>validate</phase>
                         <goals>
                             <goal>check</goal>
                         </goals>
-                        <phase>compile</phase>
                     </execution>
                 </executions>
                 <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -183,64 +183,38 @@
                 </dependencies>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven-compiler-plugin.version}</version>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
-                        <id>default-compile</id>
-                        <phase>none</phase>
-                    </execution>
-                    <execution>
-                        <id>compile-plantuml-sources</id>
+                        <phase>generate-sources</phase>
                         <goals>
-                            <goal>compile</goal>
+                            <goal>add-source</goal>
                         </goals>
-                        <phase>compile</phase>
                         <configuration>
-                            <jdkToolchain>
-                                <version>1.8</version>
-                            </jdkToolchain>
-                            <source>1.8</source>
-                            <target>1.8</target>
-                            <compileSourceRoots>
-                                <compileSourceRoot>${plantuml-asl.directory}/src</compileSourceRoot>
-                            </compileSourceRoots>
-                            <showDeprecation>false</showDeprecation>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>compile-umldoclet</id>
-                        <goals>
-                            <goal>compile</goal>
-                        </goals>
-                        <phase>compile</phase>
-                        <configuration>
-                            <jdkToolchain>
-                                <version>17</version>
-                            </jdkToolchain>
-                            <release>9</release>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>default-testCompile</id>
-                        <goals>
-                            <goal>testCompile</goal>
-                        </goals>
-                        <phase>test-compile</phase>
-                        <configuration>
-                            <jdkToolchain>
-                                <version>17</version>
-                            </jdkToolchain>
-                            <release>9</release>
+                            <sources>
+                                <source>${plantuml-asl.directory}/src</source>
+                            </sources>
                         </configuration>
                     </execution>
                 </executions>
-                <configuration> <!-- defaults for compile and testCompile -->
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
+                <configuration>
                     <encoding>${project.build.sourceEncoding}</encoding>
                     <showDeprecation>true</showDeprecation>
+                    <jdkToolchain>
+                        <version>17</version>
+                    </jdkToolchain>
+                    <release>9</release>
+<!--
                     <source>9</source>
                     <target>9</target>
+-->
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.release>9</maven.compiler.release>
 
         <!-- Plant UML apache-licensed sources: https://sourceforge.net/projects/plantuml/files/ -->
         <plantuml-asl.directory>${project.basedir}/src/plantuml-asl</plantuml-asl.directory>
@@ -78,10 +79,6 @@
         <logback.version>1.2.10</logback.version>
         <maven-invoker.version>3.1.0</maven-invoker.version>
 
-        <!--
-            This compiler plugin version fails in testComple on jdk >= jdk9-ea167:
-            https://issues.apache.org/jira/browse/MCOMPILER-294
-         -->
         <maven-compiler-plugin.version>3.9.0</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
         <maven-failsafe-plugin.version>3.0.0-M5</maven-failsafe-plugin.version>
@@ -204,18 +201,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin.version}</version>
-                <configuration>
-                    <encoding>${project.build.sourceEncoding}</encoding>
-                    <showDeprecation>true</showDeprecation>
-                    <jdkToolchain>
-                        <version>17</version>
-                    </jdkToolchain>
-                    <release>9</release>
-<!--
-                    <source>9</source>
-                    <target>9</target>
--->
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -290,9 +275,6 @@
                                 <artifactId>umldoclet</artifactId>
                                 <version>${project.version}</version>
                             </docletArtifact>
-                            <jdkToolchain>
-                                <version>17</version>
-                            </jdkToolchain>
                             <sourcepath>${project.build.sourceDirectory}:${plantuml-asl.directory}/src</sourcepath>
                             <excludePackageNames>gen.*:h:net.sourceforge.*:smetana.*</excludePackageNames>
                             <additionalOptions>


### PR DESCRIPTION
PlantUML can now be compiled using a modern (> 1.8) JDK so the complicated multi-stage build is no longer necessary.
