### PR TITLE
Refactor Design Smell : Cyclic dependency between Namespace and TypeName refactored.

### DIFF
--- a/src/main/java/nl/talsmasoftware/umldoclet/javadoc/UMLFactory.java
+++ b/src/main/java/nl/talsmasoftware/umldoclet/javadoc/UMLFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Talsma ICT
+ * Copyright 2016-2024 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -457,7 +457,7 @@ public class UMLFactory {
                         Reference.from(type.getName().getQualified(separator), null),
                         "--|>",
                         Reference.to(superclassName.getQualified(separator), null)));
-                if (!namespace.contains(superclassName)) {
+                if (!NamespaceService.contains(namespace, superclassName)) {
                     addForeignType(foreignTypes, superclassElement);
                 }
             }
@@ -472,7 +472,7 @@ public class UMLFactory {
                         interfaceRefTypeFrom(type),
                         Reference.to(interfaceName.getQualified(separator), null)));
                 // TODO Figure out what to do IF the interface is found BUT has a different typename
-                if (!namespace.contains(interfaceName)) {
+                if (!NamespaceService.contains(namespace, interfaceName)) {
                     addForeignType(foreignTypes, env.getTypeUtils().asElement(interfaceType));
                 }
             }
@@ -497,7 +497,7 @@ public class UMLFactory {
                 .forEach(field -> {
                     String fieldName = field.getSimpleName().toString();
                     TypeNameWithCardinality fieldType = typeNameWithCardinality.apply(field.asType());
-                    if (namespace.contains(fieldType.typeName)) {
+                    if (NamespaceService.contains(namespace, fieldType.typeName)) {
                         addReference(references, new Reference(
                                 Reference.from(type.getName().getQualified(separator), null),
                                 "-->",
@@ -516,7 +516,7 @@ public class UMLFactory {
                     String propertyName = propertyName(method);
                     if (propertyName != null) {
                         TypeNameWithCardinality returnType = typeNameWithCardinality.apply(propertyType(method));
-                        if (namespace.contains(returnType.typeName)) {
+                        if (NamespaceService.contains(namespace, returnType.typeName)) {
                             addReference(references, new Reference(
                                     Reference.from(type.getName().getQualified(separator), null),
                                     "-->",

--- a/src/main/java/nl/talsmasoftware/umldoclet/uml/Namespace.java
+++ b/src/main/java/nl/talsmasoftware/umldoclet/uml/Namespace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Talsma ICT
+ * Copyright 2016-2024 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,9 +65,14 @@ public class Namespace extends UMLNode {
         return output;
     }
 
-    public boolean contains(TypeName typeName) {
+    /**
+     * To break Cyclically-dependent Modularization between Namespace and TypeName and to
+     * change bidirectional association to unidirectional association NamespaceService class
+     * is created with contains method.
+     */
+/*    public boolean contains(TypeName typeName) {
         return typeName != null && typeName.qualified.startsWith(this.name + ".");
-    }
+    }*/
 
     @Override
     public int hashCode() {

--- a/src/main/java/nl/talsmasoftware/umldoclet/uml/NamespaceService.java
+++ b/src/main/java/nl/talsmasoftware/umldoclet/uml/NamespaceService.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016-2024 Talsma ICT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nl.talsmasoftware.umldoclet.uml;
+
+/**
+ * To break Cyclically-dependent Modularization between Namespace and TypeName and to
+ * change bidirectional association to unidirectional association this class
+ * is created with contains method.
+ */
+public class NamespaceService {
+    private NamespaceService() {
+    }
+    public static boolean contains(Namespace namespace, TypeName typeName) {
+        return typeName != null && typeName.qualified.startsWith(namespace.name + ".");
+    }
+}


### PR DESCRIPTION
### Refactored design smell

**Namespace** - To remove cyclic dependency between Namespace and TypeName, New class NameSpaceService created with contains method and method calling changed from Namespace to NamespaceService in findPackageReferences method of UMLFactory.

Note : If you accept PR #564 (Refactoring UMLFactory) then you need to change method calling in findPackageReferences of PackageDiagramVisitor class.