### PR TITLE
Refactored some implementation smells

### DIFF
--- a/src/main/java/nl/talsmasoftware/umldoclet/javadoc/TypeNameWithCardinality.java
+++ b/src/main/java/nl/talsmasoftware/umldoclet/javadoc/TypeNameWithCardinality.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 Talsma ICT
+ * Copyright 2016-2024 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,11 +21,7 @@ import javax.lang.model.type.ArrayType;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Types;
-import java.util.ArrayDeque;
-import java.util.HashSet;
-import java.util.Optional;
-import java.util.Queue;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Function;
 
 import static java.util.Collections.singleton;
@@ -57,7 +53,7 @@ final class TypeNameWithCardinality {
      * @param typeUtils The type utils to use for supertype introspection (required).
      * @return The function to return TypeName with cardinality for use in same-package references.
      */
-    static Function<TypeMirror, TypeNameWithCardinality> function(final Types typeUtils) {
+    /*static Function<TypeMirror, TypeNameWithCardinality> function(final Types typeUtils) {
         requireNonNull(typeUtils, "Type utils are <null>.");
         return type -> {
             if (type instanceof ArrayType) {
@@ -94,5 +90,61 @@ final class TypeNameWithCardinality {
 
             return new TypeNameWithCardinality(TypeNameVisitor.INSTANCE.visit(type), null);
         };
+    }*/
+
+
+    /**
+     * function method was Complex Method. So it is refactored using extract methods to reduce Cyclomatic complexity.
+     */
+    static Function<TypeMirror, TypeNameWithCardinality> function(final Types typeUtils) {
+        requireNonNull(typeUtils, "Type utils are <null>.");
+        return type -> {
+            if (type instanceof ArrayType) {
+                return handleArrayType((ArrayType) type, typeUtils);
+            } else if (type instanceof DeclaredType) {
+                return handleDeclaredType((DeclaredType) type, typeUtils);
+            } else {
+                return new TypeNameWithCardinality(TypeNameVisitor.INSTANCE.visit(type), null);
+            }
+        };
+    }
+
+    private static TypeNameWithCardinality handleArrayType(ArrayType arrayType, Types typeUtils) {
+        TypeName componentName = TypeNameVisitor.INSTANCE.visit(arrayType.getComponentType());
+        return new TypeNameWithCardinality(componentName, "*");
+    }
+
+    private static TypeNameWithCardinality handleDeclaredType(DeclaredType declaredType, Types typeUtils) {
+        Queue<TypeMirror> superTypes = new ArrayDeque<>(Collections.singleton(declaredType));
+        Set<String> checkedTypes = new HashSet<>();
+        while (!superTypes.isEmpty()) {
+            TypeMirror superType = superTypes.poll();
+            String qName = TypeNameVisitor.INSTANCE.visit(superType).qualified;
+            if (checkedTypes.add(qName)) { // Don't reiterate
+                TypeNameWithCardinality typeNameWithCardinality = checkCardinality(superType, qName);
+                if (typeNameWithCardinality != null) return typeNameWithCardinality;
+                superTypes.addAll(typeUtils.directSupertypes(superType));
+            }
+        }
+        return new TypeNameWithCardinality(TypeNameVisitor.INSTANCE.visit(declaredType), null);
+    }
+
+    private static TypeNameWithCardinality checkCardinality(TypeMirror superType, String qualifiedName) {
+        String cardinality;
+        if ("java.util.Optional".equals(qualifiedName) || "com.google.common.base.Optional".equals(qualifiedName)) {
+            cardinality = "0..1";
+        } else if ("java.lang.Iterable".equals(qualifiedName) || "java.util.stream.Stream".equals(qualifiedName)) {
+            cardinality = "*";
+        } else {
+            cardinality = null;
+        }
+
+        // Assumption: the 'iterable' and 'optional' types are DeclaredTypes with a single TypeArgument.
+        Optional<TypeName> typeArgument = Optional.ofNullable(cardinality)
+                .map(c -> superType instanceof DeclaredType ? (DeclaredType) superType : null)
+                .map(DeclaredType::getTypeArguments)
+                .map(args -> args.size() == 1 ? args.get(0) : null)
+                .map(TypeNameVisitor.INSTANCE::visit);
+        return typeArgument.map(ta -> new TypeNameWithCardinality(ta, cardinality)).orElse(null);
     }
 }

--- a/src/main/java/nl/talsmasoftware/umldoclet/javadoc/TypeNameWithCardinality.java
+++ b/src/main/java/nl/talsmasoftware/umldoclet/javadoc/TypeNameWithCardinality.java
@@ -53,49 +53,6 @@ final class TypeNameWithCardinality {
      * @param typeUtils The type utils to use for supertype introspection (required).
      * @return The function to return TypeName with cardinality for use in same-package references.
      */
-    /*static Function<TypeMirror, TypeNameWithCardinality> function(final Types typeUtils) {
-        requireNonNull(typeUtils, "Type utils are <null>.");
-        return type -> {
-            if (type instanceof ArrayType) {
-                TypeName componentName = TypeNameVisitor.INSTANCE.visit(((ArrayType) type).getComponentType());
-                return new TypeNameWithCardinality(componentName, "*");
-            } else if (type instanceof DeclaredType) {
-                Queue<TypeMirror> superTypes = new ArrayDeque<>(singleton(type));
-                Set<String> checkedTypes = new HashSet<>();
-                while (!superTypes.isEmpty()) {
-                    TypeMirror superType = superTypes.poll();
-                    String qName = TypeNameVisitor.INSTANCE.visit(superType).qualified;
-                    if (checkedTypes.add(qName)) { // Don't reiterate
-                        String cardinality = null;
-                        if ("java.util.Optional".equals(qName) || "com.google.common.base.Optional".equals(qName)) {
-                            cardinality = "0..1";
-                        } else if ("java.lang.Iterable".equals(qName) || "java.util.stream.Stream".equals(qName)) {
-                            cardinality = "*";
-                        }
-
-                        // Assumption: the 'iterable' and 'optional' types are DeclaredTypes with a single TypeArgument.
-                        Optional<TypeName> typeArgument = Optional.ofNullable(cardinality)
-                                .map(c -> superType instanceof DeclaredType ? (DeclaredType) superType : null)
-                                .map(DeclaredType::getTypeArguments)
-                                .map(args -> args.size() == 1 ? args.get(0) : null)
-                                .map(TypeNameVisitor.INSTANCE::visit);
-                        if (typeArgument.isPresent()) {
-                            return new TypeNameWithCardinality(typeArgument.get(), cardinality);
-                        }
-
-                        superTypes.addAll(typeUtils.directSupertypes(superType));
-                    }
-                }
-            }
-
-            return new TypeNameWithCardinality(TypeNameVisitor.INSTANCE.visit(type), null);
-        };
-    }*/
-
-
-    /**
-     * function method was Complex Method. So it is refactored using extract methods to reduce Cyclomatic complexity.
-     */
     static Function<TypeMirror, TypeNameWithCardinality> function(final Types typeUtils) {
         requireNonNull(typeUtils, "Type utils are <null>.");
         return type -> {

--- a/src/main/java/nl/talsmasoftware/umldoclet/uml/TypeName.java
+++ b/src/main/java/nl/talsmasoftware/umldoclet/uml/TypeName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 Talsma ICT
+ * Copyright 2016-2024 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,9 +56,14 @@ public class TypeName {
         return display != null && display.name().startsWith("QUALIFIED");
     }
 
+    /**
+     * Introduced this two condition explaining variables to remove Complex Condition in getQualified method.
+     */
     public String getQualified(String separator) {
         int plen = packagename == null ? 0 : packagename.length();
-        if (qualified.length() > plen && plen > 0 && separator != null && !separator.isEmpty()) {
+        boolean hasValidLengths = qualified.length() > plen && plen > 0;
+        boolean hasValidSeparator = separator != null && !separator.isEmpty();
+        if (hasValidLengths && hasValidSeparator) {
             return packagename + separator + qualified.substring(plen + 1);
         }
         return qualified;

--- a/src/main/java/nl/talsmasoftware/umldoclet/uml/util/JavaBeanProperty.java
+++ b/src/main/java/nl/talsmasoftware/umldoclet/uml/util/JavaBeanProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 Talsma ICT
+ * Copyright 2016-2024 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,9 @@ public class JavaBeanProperty {
     private Field field;
     private Method getter;
     private Method setter;
+
+    private static final int startIndexGetSet = 3;
+    private static final int startIndexIs = 2;
 
     private JavaBeanProperty(String name) {
         this.name = name;
@@ -171,15 +174,19 @@ public class JavaBeanProperty {
      * {@code "get"}, {@code "is"} or {@code "set"}.
      * @see #propertyNameOf(TypeMember)
      */
+
+    /**
+     * Introduced startIndexGetSet, startIndexIs constants to remove Magic numbers.
+     */
     private static Optional<String> propertyNameOfAccessor(Method method) {
         Optional<String> propertyName = Optional.empty();
         if (!method.isStatic && !method.isAbstract) {
             if (isGetterMethod(method) || isSetterMethod(method)) {
                 // Method name without 'get' / 'set' decapitalized
-                propertyName = Optional.of(decapitalize(method.name.substring(3)));
+                propertyName = Optional.of(decapitalize(method.name.substring(startIndexGetSet)));
             } else if (isBooleanGetterMethod(method)) {
                 // Method name without 'is' decapitalized
-                propertyName = Optional.of(decapitalize(method.name.substring(2)));
+                propertyName = Optional.of(decapitalize(method.name.substring(startIndexIs)));
             }
         }
         return propertyName;


### PR DESCRIPTION
### Refactored Implementation smells.

**JavaBeanProperty** - Constant variables startIndexGetSet and startIndexIs are created in the class to remove Magic numbers from propertyNameOfAccessor method .

**TypeName** - Condition decomposed using hasValidLengths, hasValidSeparator variables in getQualified method.

**TypeNameWithCardinality** - function method is refactored using extract methods handleArrayType, handleDeclaredType, checkCardinality because it was Complex Method.