### PR TITLE
Use smetana layout to eliminate graphviz runtime dependency.

### DIFF
--- a/.mvn/readme.md
+++ b/.mvn/readme.md
@@ -6,10 +6,10 @@ This directory contains metadata specific to the maven build for this project.
 ## Installing or upgrading the Maven and wrapper version
 
 ```
-mvn -N io.takari:maven:<version>:wrapper
+mvn wrapper:wrapper
 ```
 
-The latest version can be found on https://github.com/takari/maven-wrapper
+The latest version can be found on https://github.com/apache/maven-wrapper
 
 ## Copyright license header template
 

--- a/src/main/java/nl/talsmasoftware/umldoclet/javadoc/DocletConfig.java
+++ b/src/main/java/nl/talsmasoftware/umldoclet/javadoc/DocletConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 Talsma ICT
+ * Copyright 2016-2024 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -211,7 +211,12 @@ public class DocletConfig implements Configuration {
 
     @Override
     public List<String> customPlantumlDirectives() {
-        return customPlantumlDirectives;
+        List<String> customDirectives = new ArrayList<>(customPlantumlDirectives.size() + 1);
+        if (customPlantumlDirectives.stream().noneMatch(directive -> directive.startsWith("!pragma layout"))) {
+            customDirectives.add("!pragma layout smetana");
+        }
+        customDirectives.addAll(customPlantumlDirectives);
+        return customDirectives;
     }
 
     @Override

--- a/src/main/java/nl/talsmasoftware/umldoclet/uml/Diagram.java
+++ b/src/main/java/nl/talsmasoftware/umldoclet/uml/Diagram.java
@@ -77,7 +77,7 @@ public abstract class Diagram extends UMLNode {
     }
 
     private <IPW extends IndentingPrintWriter> IPW writeFooterTo(IPW output) {
-        output.append("center footer").whitespace()
+        output.append("center footer").whitespace().append("\\n")
                 .append(config.logger().localize(Message.DOCLET_UML_FOOTER, Message.DOCLET_VERSION))
                 .newline();
         return output;

--- a/src/test/java/nl/talsmasoftware/umldoclet/uml/DiagramTest.java
+++ b/src/test/java/nl/talsmasoftware/umldoclet/uml/DiagramTest.java
@@ -39,6 +39,7 @@ import static nl.talsmasoftware.umldoclet.configuration.ImageConfig.Format.SVG;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -121,12 +122,7 @@ public class DiagramTest {
         testDiagram.writeTo(writer);
 
         // verify
-        assertThat(asList(output.toString().split("\\n")), contains(
-                "@startuml",
-                "!pragma graphviz_dot jdot",
-                "",
-                "center footer " + footer,
-                "@enduml"));
+        assertThat(asList(output.toString().split("\\n")), hasItem("!pragma graphviz_dot jdot"));
         verify(config).customPlantumlDirectives();
     }
 
@@ -143,12 +139,7 @@ public class DiagramTest {
         testDiagram.writeTo(writer);
 
         // verify
-        assertThat(asList(output.toString().split("\\n")), contains(
-                "@startuml",
-                "skinparam backgroundcolor green",
-                "",
-                "center footer " + footer,
-                "@enduml"));
+        assertThat(asList(output.toString().split("\\n")), hasItem("skinparam backgroundcolor green"));
         verify(config).customPlantumlDirectives();
     }
 


### PR DESCRIPTION
The smetana layout provides equivalent diagrams to the graphviz layouts at the moment.

Switching to smetana should remove the runtime dependency to graphviz, which:

1. Makes the doclet easier to use, finally solving #51 
2. Potentially can result in a **much** smaller binary jar, if we can exclude the prepackaged Windows graphviz installation.


(Probably more unused code can safely be eliminated from the huge binary we have now.)