### PR TITLE
Feature: graphviz no longer required

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -25,8 +25,6 @@ jobs:
         env:
           GPG_SECRET_KEYS: ${{ secrets.GPG_SECRET_KEYS }}
           GPG_OWNERTRUST: ${{ secrets.GPG_OWNERTRUST }}
-      - name: Setup Graphviz
-        run: sudo apt-get install graphviz
       - name: Set up JDK 17
         id: setup-java-17
         uses: actions/setup-java@v3

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <!-- Artifact identification -->
     <groupId>nl.talsmasoftware</groupId>
     <artifactId>umldoclet</artifactId>
-    <version>2.1.3-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <!-- Project information -->

--- a/pom.xml
+++ b/pom.xml
@@ -248,8 +248,9 @@
                                 <version>${project.version}</version>
                             </docletArtifact>
                             <additionalOptions>
-                                <additionalOption>-createPumlFiles</additionalOption>
-                                <additionalOption>-failOnCyclicPackageDependencies true</additionalOption>
+                                <additionalOption>--create-puml-files</additionalOption>
+                                <additionalOption>--fail-on-cyclic-package-dependencies true</additionalOption>
+                                <!--<additionalOption>&#45;&#45;uml-custom-directive "skinparam handwritten true"</additionalOption>-->
                             </additionalOptions>
                         </configuration>
                     </execution>

--- a/readme.md
+++ b/readme.md
@@ -43,9 +43,6 @@ To use the UML Doclet, the following is required.
   For versions of javadoc from earlier JDKs, please use the [latest `1.x` UML Doclet version][v1.x].
   If you compile your java 8 or older javadocs with a more recent JDK (Javadoc version 9 or higher),
   you need to use the 2.x version.
-- An installed version of [graphviz](http://plantuml.com/graphviz-dot),
-  at least until [pure java visualization](https://github.com/talsma-ict/umldoclet/issues/51) works.
-  Graphviz needs to be compiled with [libexpat][libexpat] support.
 - The UML Doclet, the [usage page][usage] shows how.
   An apache-licensed version of [PlantUML][plantuml] is already included in the umldoclet jar.
 

--- a/src/main/java/nl/talsmasoftware/umldoclet/configuration/Configuration.java
+++ b/src/main/java/nl/talsmasoftware/umldoclet/configuration/Configuration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 Talsma ICT
+ * Copyright 2016-2024 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -154,8 +154,8 @@ public interface Configuration {
      * Custom directives to include in rendered PlantUML diagram sources.
      * <p>
      * Custom directives are rendered as-is at the top of each PlantUML diagram.
-     * For example, to use jdot for rendering,
-     * use the {@code "!pragma graphviz_dot jdot"} custom directive.
+     * For example, to render handwritten diagrams,
+     * use the {@code "skinparam handwritten true"} custom directive.
      *
      * @return Any custom PlantUML directives.
      */

--- a/src/test/java/nl/talsmasoftware/umldoclet/issues/Issue292CustomDirectiveTest.java
+++ b/src/test/java/nl/talsmasoftware/umldoclet/issues/Issue292CustomDirectiveTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 Talsma ICT
+ * Copyright 2016-2024 Talsma ICT
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ public class Issue292CustomDirectiveTest {
                 "-d", outputDir.getPath(),
                 "-doclet", UMLDoclet.class.getName(),
                 "-quiet", "--create-puml-files",
-                "--uml-custom-directive", "!pragma graphviz_dot jdot",
+                "--uml-custom-directive", "skinparam handwritten true",
                 "src/test/java/" + classAsPath + ".java"
         );
         classUml = TestUtil.read(new File(outputDir, classAsPath + ".puml"));
@@ -50,18 +50,18 @@ public class Issue292CustomDirectiveTest {
     }
 
     @Test
-    public void testPragmaInClassDiagram() {
-        assertThat(classUml, containsString("!pragma graphviz_dot jdot"));
+    public void testCustomDirectiveInClassDiagram() {
+        assertThat(classUml, containsString("skinparam handwritten true"));
     }
 
     @Test
-    public void testPragmaInPackageDiagram() {
-        assertThat(packageUml, containsString("!pragma graphviz_dot jdot"));
+    public void testCustomDirectiveInPackageDiagram() {
+        assertThat(packageUml, containsString("skinparam handwritten true"));
     }
 
     @Test
-    public void testPragmaInPackageDependenciesDiagram() {
-        assertThat(packageDependenciesUml, containsString("!pragma graphviz_dot jdot"));
+    public void testCustomDirectiveInPackageDependenciesDiagram() {
+        assertThat(packageDependenciesUml, containsString("skinparam handwritten true"));
     }
 
 }

--- a/src/test/java/nl/talsmasoftware/umldoclet/uml/DiagramTest.java
+++ b/src/test/java/nl/talsmasoftware/umldoclet/uml/DiagramTest.java
@@ -37,7 +37,6 @@ import static java.util.Collections.singletonList;
 import static nl.talsmasoftware.umldoclet.configuration.ImageConfig.Format.PNG;
 import static nl.talsmasoftware.umldoclet.configuration.ImageConfig.Format.SVG;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasToString;
@@ -112,7 +111,7 @@ public class DiagramTest {
     @Test
     public void testCustomDirective() {
         // prepare
-        when(config.customPlantumlDirectives()).thenReturn(singletonList("!pragma graphviz_dot jdot"));
+        when(config.customPlantumlDirectives()).thenReturn(singletonList("skinparam handwritten true"));
         StringWriter output = new StringWriter();
         Diagram testDiagram = new TestDiagram(config, new File("target/test-classes/custom-directive.puml"));
         IndentingPrintWriter writer = IndentingPrintWriter.wrap(output, Indentation.NONE);
@@ -122,7 +121,7 @@ public class DiagramTest {
         testDiagram.writeTo(writer);
 
         // verify
-        assertThat(asList(output.toString().split("\\n")), hasItem("!pragma graphviz_dot jdot"));
+        assertThat(asList(output.toString().split("\\n")), hasItem("skinparam handwritten true"));
         verify(config).customPlantumlDirectives();
     }
 

--- a/usage.md
+++ b/usage.md
@@ -171,10 +171,10 @@ The rest of this section lists various options that are specific to the UML docl
 #### -plantumlServerUrl &lt;url&gt;
 
 Base URL for the PlantUML server.  
-Bypass the built-in internal PlantUML version that requires graphviz to be installed,
-but use a running plantuml-server instead to generate UML diagrams.
+Bypass the built-in internal PlantUML version and
+use a remote plantuml-server instead to generate UML diagrams.
 
-You can run a plantuml-server using docker:
+You can locally run a plantuml-server using docker:
 
 ```shell
 docker run -d -p 8080:8080 plantuml/plantuml-server:latest


### PR DESCRIPTION
This PR removes reference to graphviz from documentation and readme's since it is no longer required.

This PR (finally) fixes #51 